### PR TITLE
Create value_and_data_template

### DIFF
--- a/examples/value_and_data_template
+++ b/examples/value_and_data_template
@@ -1,0 +1,24 @@
+- id: posta_state_change
+  alias: 'Posta state change'
+  hide_entity: true
+  initial_state: 'true'
+  trigger:
+    platform: state
+    entity_id: sensor.cp_packages_coming_today
+  condition:
+    condition: state
+    entity_id: 'sensor.cp_packages_coming_today'
+    state: 'Delivery'
+  action:
+    service: variable.set_variable
+    data:
+      variable: posta_variable
+      attributes_template: >
+        {
+          "from": "{{ state_attr('sensor.cp_packages_coming_today', 'from') }}",
+          "date": "{{ state_attr('sensor.cp_packages_coming_today', 'date') }}",
+          "subject": "{{ state_attr('sensor.cp_packages_coming_today', 'subject') }}"
+        }
+    data_template:
+      value: >
+          {{ states('sensor.cp_packages_coming_today')}}


### PR DESCRIPTION
It was very difficult to find the correct syntax for using both a variable_template and attributes_template in a variable setting. After about 50 tries, this works. I hope no one ever has to figure this out again.