### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/variable/manifest.json
+++ b/custom_components/variable/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "variable",
     "name": "variable",
+    "version": "1.0.0",
     "documentation": "https://github.com/rogro82/hass-variables",
     "requirements": [],
     "dependencies": [],


### PR DESCRIPTION
since home assistant 2021.6 a version number is required in custom components, otherwise the component can not be loaded